### PR TITLE
Improve overlay usability with filtering

### DIFF
--- a/Structure
+++ b/Structure
@@ -2,6 +2,6 @@ workmarket-transformer/
 ├── css.js                  // Contains the customCss string
 ├── utils.js                // Contains helper functions like parseFullDateToParts, parseLocationString, formatValue
 ├── scoreCalculator.js      // Contains calculateOverallScore and its sub-component logic
-├── uiManager.js            // Contains methods for creating/managing main overlay and tech modal
-├── workMarketTransformer.js // The main class, orchestrating everything
+├── uiManager.js            // Contains methods for creating/managing main overlay and tech modal (now includes a filter input)
+├── workMarketTransformer.js // The main class, orchestrating everything and applies the filter
 └── main.js                 // The entry point script (what you'd inject or use as the base for userscript)

--- a/uiManager.js
+++ b/uiManager.js
@@ -50,7 +50,7 @@ export class UIManager {
 
         const header = document.createElement('div');
         header.className = 'overlay-header';
-        header.innerHTML = `<span>WorkMarket Enhanced Assignments</span><div class="overlay-controls"><button class="overlay-minimize-btn" title="Minimize">_</button><button class="overlay-maximize-btn" title="Maximize">□</button><button class="overlay-close-btn" title="Hide">X</button></div>`;
+        header.innerHTML = `<span>WorkMarket Enhanced Assignments</span><input id="assignmentFilterInput" type="text" placeholder="Filter..." style="margin-left:10px;flex-grow:1;max-width:200px;"/><div class="overlay-controls"><button class="overlay-minimize-btn" title="Minimize">_</button><button class="overlay-maximize-btn" title="Maximize">□</button><button class="overlay-close-btn" title="Hide">X</button></div>`;
 
         this.mainOverlayContentTarget = document.createElement('div');
         this.mainOverlayContentTarget.className = 'overlay-content';


### PR DESCRIPTION
## Summary
- add assignment filter box to overlay header
- listen for filter updates in `WorkMarketTransformer`
- filter assignments by title
- document new filter input in Structure

## Testing
- `node --check workMarketTransformer.js`
- `node --check uiManager.js`


------
https://chatgpt.com/codex/tasks/task_e_684601536ecc8325893ca7de33d3505d